### PR TITLE
Add No Sandbox Option to System Tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Open an issue or
   2. Update
   3. Test
       1. `bundle exec rails app:test:all` and check coverage in `test/coverage/index.html`
+        - `bundle exec rails app:test:all NO_SANDBOX=true` when running as root
       2. `bundle exec rubocop`
       3. `bundle exec brakeman`
   4. Open pull request

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Open an issue or
   2. Update
   3. Test
       1. `bundle exec rails app:test:all` and check coverage in `test/coverage/index.html`
-        - `bundle exec rails app:test:all NO_SANDBOX=true` when running as root
+        - `NO_SANDBOX=true bundle exec rails app:test:all` when running as root
       2. `bundle exec rubocop`
       3. `bundle exec brakeman`
   4. Open pull request

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,5 +1,7 @@
 require 'test_helper'
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :selenium, using: :headless_chrome
+  driven_by :selenium, using: :headless_chrome do |option|
+    option.add_argument('no-sandbox') if ENV.fetch('NO_SANDBOX', false)
+  end
 end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -2,6 +2,6 @@ require 'test_helper'
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   driven_by :selenium, using: :headless_chrome do |option|
-    option.add_argument('no-sandbox') if ENV.fetch('NO_SANDBOX', false)
+    option.add_argument('no-sandbox') if ENV['NO_SANDBOX'] == 'true'
   end
 end


### PR DESCRIPTION
This pull request introduces a small but important improvement to the system test configuration, allowing tests to run in environments where sandboxing is not possible (such as when running as root). It also updates the documentation to reflect this new option.

Testing improvements:

* Updated `ApplicationSystemTestCase` in `test/application_system_test_case.rb` to add the `no-sandbox` Chrome option when the `NO_SANDBOX` environment variable is set, enabling system tests to run as root.

Documentation updates:

* Updated the testing instructions in `README.md` to mention running `bundle exec rails app:test:all NO_SANDBOX=true` when running as root.